### PR TITLE
2단계 - 스케일 아웃

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,112 @@ $ stress -c 2
 
 3. 성능 개선 결과를 공유해주세요 (Smoke, Load, Stress 테스트 결과)
 
+### Smoke Test
+
+```
+execution: local
+     script: smoke.js
+     output: InfluxDBv1 (http://localhost:8086)
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 40s max duration (incl. graceful stop):
+           * default: 1 looping VUs for 10s (gracefulStop: 30s)
+
+running (10.9s), 0/1 VUs, 9 complete and 0 interrupted iterations
+default ✓ [======================================] 1 VUs  10s
+
+     ✓ logged in successfully
+     ✓ retrieved member
+
+     checks.....................: 100.00% ✓ 18       ✗ 0
+     data_received..............: 8.7 kB  797 B/s
+     data_sent..................: 2.2 kB  206 B/s
+     http_req_blocked...........: avg=26.92ms  min=1µs     med=2µs     max=484.67ms p(90)=2.3µs   p(95)=72.7ms
+     http_req_connecting........: avg=704.88µs min=0s      med=0s      max=12.68ms  p(90)=0s      p(95)=1.9ms
+   ✓ http_req_duration..........: avg=76.72ms  min=22.2ms  med=31.85ms max=822.53ms p(90)=53.08ms p(95)=172.48ms
+     http_req_failed............: 100.00% ✓ 18       ✗ 0
+     http_req_receiving.........: avg=1.14ms   min=71µs    med=149µs   max=8.82ms   p(90)=2.99ms  p(95)=6.83ms
+     http_req_sending...........: avg=449.88µs min=102µs   med=448µs   max=972µs    p(90)=735.4µs p(95)=823.24µs
+     http_req_tls_handshaking...: avg=17.56ms  min=0s      med=0s      max=316.17ms p(90)=0s      p(95)=47.42ms
+     http_req_waiting...........: avg=75.12ms  min=21.69ms med=29.78ms max=821.85ms p(90)=52.63ms p(95)=171.84ms
+     http_reqs..................: 18      1.651325/s
+     iteration_duration.........: avg=1.21s    min=1.05s   med=1.06s   max=2.36s    p(90)=1.33s   p(95)=1.84s
+     iterations.................: 9       0.825662/s
+     vus........................: 1       min=1      max=1
+     vus_max....................: 1       min=1      max=1
+```
+
+### Load Test
+
+```
+execution: local
+     script: load.js
+     output: -
+
+scenarios: (100.00%) 1 scenario, 6 max VUs, 30m30s max duration (incl. graceful stop):
+         * default: Up to 6 looping VUs for 30m0s over 6 stages (gracefulRampDown: 30s, gracefulStop: 30s)
+
+running (30m00.0s), 0/6 VUs, 97541 complete and 0 interrupted iterations
+default ✓ [======================================] 0/6 VUs  30m0s
+
+   ✓ Randing page status check
+   ✓ Paths Page status check
+   ✓ Path api status check
+
+   checks.........................: 100.00% ✓ 292623    ✗ 0
+   data_received..................: 344 MB  191 kB/s
+   data_sent......................: 13 MB   7.2 kB/s
+   http_req_blocked...............: avg=86.7µs   min=0s      med=1µs     max=479.97ms p(90)=1µs      p(95)=2µs
+   http_req_connecting............: avg=23.61µs  min=0s      med=0s      max=169.38ms p(90)=0s       p(95)=0s
+ ✓ http_req_duration..............: avg=23.26ms  min=10.43ms med=16.07ms max=544.06ms p(90)=32.04ms  p(95)=44.31ms
+     { expected_response:true }...: avg=23.26ms  min=10.43ms med=16.07ms max=544.06ms p(90)=32.04ms  p(95)=44.31ms
+   http_req_failed................: 0.00%   ✓ 0         ✗ 292623
+   http_req_receiving.............: avg=78µs     min=5µs     med=49µs    max=23.13ms  p(90)=114µs    p(95)=179µs
+   http_req_sending...............: avg=120.11µs min=10µs    med=71µs    max=24.15ms  p(90)=191µs    p(95)=316µs
+   http_req_tls_handshaking.......: avg=61.4µs   min=0s      med=0s      max=466.11ms p(90)=0s       p(95)=0s
+   http_req_waiting...............: avg=23.06ms  min=49µs    med=15.9ms  max=543.93ms p(90)=31.87ms  p(95)=44.1ms
+   http_reqs......................: 292623  162.56404/s
+   iteration_duration.............: avg=70.71ms  min=33.35ms med=52.08ms max=815.1ms  p(90)=100.69ms p(95)=203.87ms
+   iterations.....................: 97541   54.188013/s
+   vus............................: 3       min=1       max=6
+   vus_max........................: 6       min=6       max=6
+```
+
+### Stress
+
+```
+execution: local
+   script: stress.js
+   output: -
+
+scenarios: (100.00%) 1 scenario, 120 max VUs, 23m30s max duration (incl. graceful stop):
+         * default: Up to 120 looping VUs for 23m0s over 7 stages (gracefulRampDown: 30s, gracefulStop: 30s)
+
+running (23m00.1s), 000/120 VUs, 760911 complete and 0 interrupted iterations
+default ✓ [======================================] 000/120 VUs  23m0s
+
+   ✓ Randing page status check
+   ✓ Paths Page status check
+   ✓ Path api status check
+
+   checks.........................: 100.00% ✓ 2282733     ✗ 0
+   data_received..................: 2.7 GB  1.9 MB/s
+   data_sent......................: 99 MB   72 kB/s
+   http_req_blocked...............: avg=8.04µs   min=0s      med=0s      max=217.69ms p(90)=1µs     p(95)=1µs
+   http_req_connecting............: avg=2.26µs   min=0s      med=0s      max=76.48ms  p(90)=0s      p(95)=0s
+ ✓ http_req_duration..............: avg=17.28ms  min=10.23ms med=16.56ms max=391.34ms p(90)=20.94ms p(95)=23.23ms
+     { expected_response:true }...: avg=17.28ms  min=10.23ms med=16.56ms max=391.34ms p(90)=20.94ms p(95)=23.23ms
+   http_req_failed................: 0.00%   ✓ 0           ✗ 2282733
+   http_req_receiving.............: avg=264.36µs min=3µs     med=20µs    max=252.53ms p(90)=553µs   p(95)=1.64ms
+   http_req_sending...............: avg=44.73µs  min=4µs     med=26µs    max=29.57ms  p(90)=59µs    p(95)=86µs
+   http_req_tls_handshaking.......: avg=5.15µs   min=0s      med=0s      max=141.05ms p(90)=0s      p(95)=0s
+   http_req_waiting...............: avg=16.97ms  min=0s      med=16.32ms max=390.8ms  p(90)=20.37ms p(95)=22.48ms
+   http_reqs......................: 2282733 1654.058257/s
+   iteration_duration.............: avg=52.11ms  min=35.28ms med=50.63ms max=497.63ms p(90)=61.03ms p(95)=65.21ms
+   iterations.....................: 760911  551.352752/s
+   vus............................: 119     min=1         max=119
+   vus_max........................: 120     min=120       max=120
+```
+
 ### 3단계 - 쿠버네티스로 구성하기
 1. 클러스터를 어떻게 구성했는지 알려주세요~ (마스터 노드 : n 대, 워커 노드 n대)
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ https://ap-northeast-2.console.aws.amazon.com/ec2/home?region=ap-northeast-2#Lau
 
 2. cpu 부하 실행 후 EC2 추가생성 결과를 공유해주세요. (Cloudwatch 캡쳐)
 
-기존 설정을 3 대 가용해서 시작했는데, CPU 점유율이 높아지지 않아 줄어드는 것을 확인했습니다..!
+CPU가 50% 기준으로 인스턴스를 늘리도록 설정했고, 부하테스트를 진행한 결과와 같이 인스턴스 개수가 늘어난 것을 확인했습니다.
 
-<img width="1103" alt="스크린샷 2022-12-16 오전 1 39 15" src="https://user-images.githubusercontent.com/92219795/207917552-7d971f5c-d521-4342-a904-37fc5c9e5c8a.png">
+<img width="278" alt="스크린샷 2022-12-16 오전 10 53 57" src="https://user-images.githubusercontent.com/92219795/208003960-cf7c08e9-82d8-4572-b1d6-ac45fbf2b3a9.png">
+
+<img width="1085" alt="스크린샷 2022-12-16 오전 10 53 43" src="https://user-images.githubusercontent.com/92219795/208003937-aa9028b5-4e7d-4379-ab3e-2d358fd90529.png">
+
+> 최대 개수로 지정한 7대 보다 넘을 것을 고려해서 20대로 변경했습니다.
 
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -57,7 +57,14 @@ npm run dev
 
 1. Launch Template 링크를 공유해주세요.
 
+https://ap-northeast-2.console.aws.amazon.com/ec2/home?region=ap-northeast-2#LaunchTemplateDetails:launchTemplateId=lt-07ad780a983efd43e
+
 2. cpu 부하 실행 후 EC2 추가생성 결과를 공유해주세요. (Cloudwatch 캡쳐)
+
+기존 설정을 3 대 가용해서 시작했는데, CPU 점유율이 높아지지 않아 줄어드는 것을 확인했습니다..!
+
+<img width="1103" alt="스크린샷 2022-12-16 오전 1 39 15" src="https://user-images.githubusercontent.com/92219795/207917552-7d971f5c-d521-4342-a904-37fc5c9e5c8a.png">
+
 
 ```sh
 $ stress -c 2

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
+	// mysql
+	implementation("mysql:mysql-connector-java")
+	
 	testImplementation 'io.rest-assured:rest-assured:3.3.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,5 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://192.168.234.140:3306/subway?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=masterpw
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
안녕하세요! 🙇‍♂️
제가 고려한 스트레스 테스트는 CPU 점유율이 30 퍼센트를 채 넘기지 못해서 고정적으로 서버 3 대를 가용해서 테스트를 진행했고, 추가적으로 500 VUser 까지 고려해 웹 성능의 한계를 측정했습니다.


### 1 대에서 3 대로 변경한 Stress Test

**AS-IS**

<img width="1421" alt="스크린샷 2022-12-15 오후 1 15 16" src="https://user-images.githubusercontent.com/92219795/207771140-be48c751-93b0-43c4-bf07-252efa803284.png">


**TO-BE**

<img width="1405" alt="스크린샷 2022-12-16 오전 1 14 04" src="https://user-images.githubusercontent.com/92219795/207911418-56ab6ad3-d196-48f5-bb18-37dd0fd38308.png">

### 추가 : 오토 스케일링을 경험한 Stress Test

CPU가 50% 기준으로 인스턴스를 늘리도록 설정했고, 부하테스트를 진행한 결과와 같이 인스턴스 개수가 늘어난 것을 확인했습니다.

<img width="278" alt="스크린샷 2022-12-16 오전 10 53 57" src="https://user-images.githubusercontent.com/92219795/208003960-cf7c08e9-82d8-4572-b1d6-ac45fbf2b3a9.png">

<img width="1085" alt="스크린샷 2022-12-16 오전 10 53 43" src="https://user-images.githubusercontent.com/92219795/208003937-aa9028b5-4e7d-4379-ab3e-2d358fd90529.png">

> 최대 개수로 지정한 7대 보다 넘을 것을 고려해서 20대로 변경했습니다.

###  두 번째 Stress Test 결과

```
running (32m00.1s), 000/500 VUs, 6376279 complete and 0 interrupted iterations
default ✓ [======================================] 000/500 VUs  32m0s

     ✗ Randing page status check
      ↳  83% — ✓ 5296848 / ✗ 1079431
     ✗ Paths Page status check
      ↳  83% — ✓ 5295429 / ✗ 1080850
     ✗ Path api status check
      ↳  83% — ✓ 5298439 / ✗ 1077840

     checks.........................: 83.07%   ✓ 15890716    ✗ 3238121
     data_received..................: 19 GB    10 MB/s
     data_sent......................: 830 MB   433 kB/s
     http_req_blocked...............: avg=7.76µs   min=0s      med=0s      max=581.25ms p(90)=1µs     p(95)=1µs
     http_req_connecting............: avg=2.39µs   min=0s      med=0s      max=142.59ms p(90)=0s      p(95)=0s
   ✓ http_req_duration..............: avg=23.46ms  min=10.04ms med=20.64ms max=14.3s    p(90)=31.92ms p(95)=34.64ms
       { expected_response:true }...: avg=23.75ms  min=10.04ms med=21.44ms max=14.02s   p(90)=32.69ms p(95)=35.2ms
     http_req_failed................: 16.92%   ✓ 3238121     ✗ 15890716
     http_req_receiving.............: avg=129.33µs min=4µs     med=10µs    max=4.46s    p(90)=192µs   p(95)=633µs
     http_req_sending...............: avg=22.1µs   min=5µs     med=18µs    max=65.53ms  p(90)=28µs    p(95)=37µs
     http_req_tls_handshaking.......: avg=5.13µs   min=0s      med=0s      max=535.77ms p(90)=0s      p(95)=0s
     http_req_waiting...............: avg=23.31ms  min=0s      med=20.48ms max=14.3s    p(90)=31.76ms p(95)=34.46ms
     http_reqs......................: 19128837 9962.501458/s
     iteration_duration.............: avg=70.52ms  min=33.48ms med=63.11ms max=14.4s    p(90)=96.86ms p(95)=103.61ms
     iterations.....................: 6376279  3320.833819/s
     vus............................: 499      min=1         max=499
     vus_max........................: 500      min=500       max=500

```

### 부하 테스트 결론

기존 인스턴스 1 대로 가용 했을 상황에서 오토스케일링을 적용한 상황의 성능을 비교하면 `20rps` 에서 `120rps`로 성능이 개선된걸 볼 수 있습니다.

### 웹 성능 측정

웹 성능 테스트를 했을 때, 기존 목표치보다 떨어지는 성능을 확인할 수 있었습니다.

**데스크탑 성능 측정**

<img width="948" alt="스크린샷 2022-12-16 오전 10 56 36" src="https://user-images.githubusercontent.com/92219795/208004289-0557c1d4-1538-42e7-a9ed-84f6292fb7e7.png">

- 목표 FCP : 1.5s < 현재 : 0.7s
- 목표 TTI : 2.1s > 현재 : 2.6s
- 목표 SI : 2.2s < 현재 SI : 1.9s
- 목표 LCP : 2.6s > 현재 LCP : 2.7s


**모바일 성능 측정**

<img width="830" alt="스크린샷 2022-12-16 오전 11 12 25" src="https://user-images.githubusercontent.com/92219795/208006139-0e5d5529-9c31-4481-898d-082ad11a282a.png">

- 목표 FCP : 6.9s < 현재 : 2.5s
- 목표 TTI : 9.0s > 현재 : 14.7s
- 목표 SI : 8.6s < 현재 SI : 8.7s
- 목표 LCP : 7.7s > 현재 LCP : 15.1s

### 성능 측정 결론

- 아무래도 이전 로드밸런싱과 캐싱역할을 하던 NGINX가 제외되고, ALB가 로드밸런서 역할을 하게 되면서 캐싱 기능의 부재로 생긴 문제처럼 보입니다.
- 당연한 이야기지만, 오토스케일링은 부하 상황에서 문제를 해결할 수 있는 방법이라는 걸 경험으로 느낄 수 있었습니다. 부하 상황이 아닌 부차적인 지연 요소들은 다른 방법으로 개선할 필요가 있겠네요!

