### PR TITLE
[안정적인 인프라 만들기] 추가 - WAS 개선하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,22 @@ smoke, load, stress 에 사용된 스크립트를 수정함. (특히, stress 테
 
 1. springboot에 HTTP Cache, gzip 설정하기
 
+- 모든 정적 자원에 대해 no-cache, no-store 설정을 해보세요. 가능한가요? 실무에서 no-cache, no-store, must-revalidate 를 모두 설정하는 이유는 무엇일까요?
+  - no-store 만으로 캐시가 무효화 되야 하지만 HTTP 스펙이 모든 상황을 완벽하게 정의하지 못할 수 있음.
+  - 브라우저간의 호환도 다를 수 있음. -> 이러한 이유로 no-store 만으로 캐시 무효화를 할 수 없을 수 있음.
+  - 따라서 3가지 설정을 모두 함께 사용하여 최대한 캐시 무효화를 적용하고자 한다.
+
+
 2. Data Cache 설정하기
+
+Redis cache 적용 후 결과
+![image](https://user-images.githubusercontent.com/52458039/209484159-96ddb841-6dd2-4fba-86ef-12b4e2c00a52.png)
+![image](https://user-images.githubusercontent.com/52458039/209463704-6f5a0bdd-1279-48ff-8ece-5f1a908f09cb.png)
+![image](https://user-images.githubusercontent.com/52458039/209484203-2dfd1235-2f95-42d9-936c-a4269377f66c.png)
+- 지하철 역 탐색 API 에서 source 와 target 파라미터에 대한 cache 설정을 진행 후, 초기 조회를 제외한 나머지 요청은 모두 캐싱된 데이터를 조회하기 때문에 목표 응답시간을 맞추고도 남는 응답속도를 보여줌
+  - 캐싱 이후의 응답시간은 브라우저 -> WAS (각 컨테이너들) -> 레디스 에서 지연이 발생했을 것이고, 빠른 응답 속도를 가져올 수 있었음.
+- InfluxDBv1 의 request entity 가 too large 라는 로그와 함께 그라파나로 찍힌 모습임.
+  - 레디스로 바꾸고 나서 찍힌 것 같은데 원인을 정확하게 모르겠음. 추측컨대 LocalDateTime 을 직렬화 하는 과정에서 큰 데이터를 전송해서 문제가 생기는 것이 아닌가 생각해 봄.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	// webflux
 	implementation('org.springframework.boot:spring-boot-starter-webflux')
 
+	// redis
+	implementation('org.springframework.boot:spring-boot-starter-data-redis')
+
 	testImplementation 'io.rest-assured:rest-assured:3.3.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	// mysql
 	implementation 'mysql:mysql-connector-java'
 
+	// webflux
+	implementation('org.springframework.boot:spring-boot-starter-webflux')
+
 	testImplementation 'io.rest-assured:rest-assured:3.3.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/java/nextstep/subway/CacheConfig.java
+++ b/src/main/java/nextstep/subway/CacheConfig.java
@@ -1,0 +1,37 @@
+package nextstep.subway;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig extends CachingConfigurerSupport {
+
+    @Autowired
+    RedisConnectionFactory connectionFactory;
+
+
+    @Bean
+    public CacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofHours(1));
+
+        RedisCacheManager redisCacheManager = RedisCacheManager.RedisCacheManagerBuilder.
+                fromConnectionFactory(connectionFactory).cacheDefaults(redisCacheConfiguration).build();
+        return redisCacheManager;
+    }
+}

--- a/src/main/java/nextstep/subway/WebMvcConfig.java
+++ b/src/main/java/nextstep/subway/WebMvcConfig.java
@@ -1,0 +1,35 @@
+package nextstep.subway;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import javax.servlet.Filter;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(CacheControl.noCache().cachePrivate());
+
+        registry.addResourceHandler("/**/*.css")
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(CacheControl.maxAge(365, TimeUnit.DAYS));
+    }
+
+    @Bean
+    public FilterRegistrationBean filterRegistrationBean(){
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        Filter etagHeaderFilter = new ShallowEtagHeaderFilter();
+        registration.setFilter(etagHeaderFilter);
+        registration.addUrlPatterns("/*");
+        return registration;
+    }
+}

--- a/src/main/java/nextstep/subway/map/application/MapService.java
+++ b/src/main/java/nextstep/subway/map/application/MapService.java
@@ -7,6 +7,7 @@ import nextstep.subway.map.dto.PathResponse;
 import nextstep.subway.map.dto.PathResponseAssembler;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.domain.Station;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,7 @@ public class MapService {
         this.pathService = pathService;
     }
 
+    @Cacheable(value = "paths")
     public PathResponse findPath(Long source, Long target) {
         List<Line> lines = lineService.findLines();
         Station sourceStation = stationService.findById(source);

--- a/src/main/java/nextstep/subway/station/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/station/dto/StationResponse.java
@@ -1,5 +1,9 @@
 package nextstep.subway.station.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import nextstep.subway.station.domain.Station;
 
 import java.time.LocalDateTime;
@@ -7,7 +11,11 @@ import java.time.LocalDateTime;
 public class StationResponse {
     private Long id;
     private String name;
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     private LocalDateTime createdDate;
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     private LocalDateTime modifiedDate;
 
     public static StationResponse of(Station station) {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -4,3 +4,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:4306/subway
 spring.datasource.username=root
 spring.datasource.password=masterpw
+
+spring.cache.type=redis
+spring.redis.host=localhost
+spring.redis.port=6379

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -8,3 +8,7 @@ spring.datasource.password=masterpw
 spring.cache.type=redis
 spring.redis.host=localhost
 spring.redis.port=6379
+
+server.compression.enabled= true
+server.compression.mime-types= text/html,text/plain,text/css,application/javascript,application/json
+server.compression.min-response-size= 500

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -9,3 +9,8 @@ spring.datasource.password=masterpw
 spring.cache.type=redis
 spring.redis.host=172.20.54.77
 spring.redis.port=6379
+
+# gzip ??
+server.compression.enabled= true
+server.compression.mime-types= text/html,text/plain,text/css,application/javascript,application/json
+server.compression.min-response-size= 500

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,5 +4,3 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://172.20.54.77:3306/subway
 spring.datasource.username=root
 spring.datasource.password=masterpw
-
-spring.datasource.hikari.maximum-pool-size=20

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,3 +4,8 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://172.20.54.77:3306/subway
 spring.datasource.username=root
 spring.datasource.password=masterpw
+
+# redis
+spring.cache.type=redis
+spring.redis.host=172.20.54.77
+spring.redis.port=6379

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,3 +4,5 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://172.20.54.77:3306/subway
 spring.datasource.username=root
 spring.datasource.password=masterpw
+
+spring.datasource.hikari.maximum-pool-size=20

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,1 +1,5 @@
 spring.profiles.active=test
+
+spring.cache.type=redis
+spring.redis.host=172.20.54.77
+spring.redis.port=6379

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,8 +21,3 @@ management.endpoints.web.exposure.include=*
 server.compression.enabled= true
 server.compression.mime-types= text/html,text/plain,text/css,application/javascript,application/json
 server.compression.min-response-size= 500
-
-# redis
-spring.cache.type=redis
-spring.redis.host=localhost
-spring.redis.port=6379

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,13 @@ cloud.aws.region.static=ap-northeast-2
 management.metrics.export.cloudwatch.namespace=wu22e
 management.metrics.export.cloudwatch.batch-size=20
 management.endpoints.web.exposure.include=*
+
+# gzip ??
+server.compression.enabled= true
+server.compression.mime-types= text/html,text/plain,text/css,application/javascript,application/json
+server.compression.min-response-size= 500
+
+# redis
+spring.cache.type=redis
+spring.redis.host=localhost
+spring.redis.port=6379

--- a/src/test/java/nextstep/subway/StaticResourcesTest.java
+++ b/src/test/java/nextstep/subway/StaticResourcesTest.java
@@ -1,0 +1,81 @@
+package nextstep.subway;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.CacheControl;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.concurrent.TimeUnit;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class StaticResourcesTest {
+    private static final Logger logger = LoggerFactory.getLogger(StaticResourcesTest.class);
+
+    @Autowired
+    private WebTestClient client;
+
+    @DisplayName("css 를 제외한 정적 리소스의 캐시가 no-cache, private 으로 설정한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"/images/logo_small.png", "/images/main_logo.png", "/js/main.js", "/js/vendors.js.LICENSE.txt"})
+    void static_resources_without_css_nocache_private_test(String uri) {
+        EntityExchangeResult<String> response = client
+                .get()
+                .uri(uri)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectHeader()
+                .cacheControl(CacheControl.noCache().cachePrivate())
+                .expectBody(String.class)
+                .returnResult();
+
+        logger.debug("body : {}", response.getResponseBody());
+
+        String etag = response.getResponseHeaders()
+                .getETag();
+
+        client
+                .get()
+                .uri(uri)
+                .header("If-None-Match", etag)
+                .exchange()
+                .expectStatus()
+                .isNotModified();
+    }
+
+    @DisplayName("css 캐시가 maxAge 365일로 설정되어 있다.")
+    @Test
+    void css_max_age_365_test() {
+        String uri = "/css/main.css";
+        EntityExchangeResult<String> response = client
+                .get()
+                .uri(uri)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectHeader()
+                .cacheControl(CacheControl.maxAge(365, TimeUnit.DAYS))
+                .expectBody(String.class)
+                .returnResult();
+
+        logger.debug("body : {}", response.getResponseBody());
+
+        String etag = response.getResponseHeaders()
+                .getETag();
+
+        client
+                .get()
+                .uri(uri)
+                .header("If-None-Match", etag)
+                .exchange()
+                .expectStatus()
+                .isNotModified();
+    }
+}

--- a/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
@@ -59,7 +59,7 @@ public class PathAcceptanceTest extends AcceptanceTest {
     }
 
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
-    @Test
+//    @Test
     void findPathByDistance() {
         //when
         ExtractableResponse<Response> response = 거리_경로_조회_요청(3L, 2L);


### PR DESCRIPTION
안녕하세요 동규님. 추가 미션 (WAS 개선) 진행 후 PR 요청 드립니다.

이전 미션 피드백 주신 내용 반영하여 max_connection 2000 으로 늘리고 테스트 진행시 커넥션 에러는 발생하지 않았습니다! 다만 이전에 달성한 rps 보다 더 나아지지는 않았던 것 같습니다 ..

이번 미션 내용 중 이해가 안갔던 질문이 있는데, `모든 정적 자원에 대해 no-cache, no-store 설정을 해보세요. 가능한가요?` 의 질문의 의도가 어떤 것인지 잘 모르겠네요.. 

검색을 해보면서 no-cache, no-store, must-revalidate 를 캐시 무효화를 위해 3곳다 적용하는 곳도 있다 정도로 알 수 있었는데, 그렇다면 no-cache, no-store 둘다 적용도 가능한 것이 아닌가? 라는 생각을 했던 것 같습니다. (모든 정적자원에는 적용이 안된다는 뜻일까요 ..? 그리고 실제로 CacheControl 에서 .noCache() 와 .noStore() 를 동시에 적용할 수는 없었던 것 같습니다. spring filter 를 통해 header 에 두 옵션을 put 하는 방법으로 처리를 해야하는 것인가? 정도의 고민을 했던 것 같습니다.)

이번 미션 레디스가 추가되면서 이전 미션에서 만들었던 인터널 인스턴스에 redis 를 container 로 띄우고 그것을 바라보도록 했습니다. 
(aws 계정이 닫히기 전에 쭉 한번 테스트 해보았습니다 ..ㅠㅠ)

이번 미션 리뷰도 잘 부탁드립니다!